### PR TITLE
[FEAT] 인증을 위한 @AuthenticationMember 커스텀 어노테이션 구현

### DIFF
--- a/src/main/java/com/otechdong/moyeo/domain/config/AuthenticationMember.java
+++ b/src/main/java/com/otechdong/moyeo/domain/config/AuthenticationMember.java
@@ -1,0 +1,14 @@
+package com.otechdong.moyeo.domain.config;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@AuthenticationPrincipal(expression = "#this == 'annoymousUser' ? null : member")
+public @interface AuthenticationMember {
+}

--- a/src/main/java/com/otechdong/moyeo/domain/config/SecurityConfig.java
+++ b/src/main/java/com/otechdong/moyeo/domain/config/SecurityConfig.java
@@ -51,9 +51,10 @@ public class SecurityConfig {
         // 경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/login", "/", "/join", "/env", "/health-check").permitAll()
+                        .requestMatchers("/env", "/health-check", "/base-response", "/error-handler").permitAll()
                         .requestMatchers("/members/sign-in").permitAll()
-                        .anyRequest().authenticated());
+                        .requestMatchers("/test").authenticated()
+                        .anyRequest().denyAll());
         http
                 .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/otechdong/moyeo/domain/config/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/otechdong/moyeo/domain/config/jwt/filter/JwtFilter.java
@@ -20,28 +20,37 @@ public class JwtFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 //        토큰 추출
         String authorization = request.getHeader("Authorization");
-        String refreshToken = request.getHeader("Refresh-Token");
+//        String refreshToken = request.getHeader("Refresh-Token");
 //        토큰 유형 검증
         if (authorization == null || !authorization.startsWith("Bearer ")) {
             filterChain.doFilter(request, response);
             return;
         }
-
+        // Log
+        System.out.println(authorization);
 //        토큰 분리
-        String accessToken = authorization.split(" ")[1];
+        String token = authorization.split(" ")[1];
+
+        // Log
+        System.out.println(token);
+
 //        토큰 만료 여부 확인
-        if (jwtUtil.isExpired(accessToken)) {
+        if (jwtUtil.isExpired(token)) {
             filterChain.doFilter(request, response);
             return;
         }
+
+        // Log
+        System.out.println(token);
+
 //        토큰에서 tokenType 추출
-        String tokenType = jwtUtil.getTokenType(accessToken);
+        String tokenType = jwtUtil.getTokenType(token);
         if (tokenType == null) {
             filterChain.doFilter(request, response);
             return;
         }
         // JWT 토큰에서 인증 정보를 추출해 Authentication(인증) 객체를 생성
-        Authentication authentication = jwtUtil.getAuthentication(accessToken);
+        Authentication authentication = jwtUtil.getAuthentication(token);
         // Spring Security의 SecurityContextHolder에 설정해 인증된 사용자로 만듦
         SecurityContextHolder.getContext().setAuthentication(authentication);
 

--- a/src/main/java/com/otechdong/moyeo/domain/config/jwt/service/JwtUtilImpl.java
+++ b/src/main/java/com/otechdong/moyeo/domain/config/jwt/service/JwtUtilImpl.java
@@ -45,6 +45,7 @@ public class JwtUtilImpl implements JwtUtil {
             throw new RestApiException(AuthErrorCode.INVALID_TOKEN_TYPE);
         }
         return Jwts.builder()
+                .claim("tokenType", "access")
                 .claim("memberId", memberId)
                 .claim("clientId", clientId)
                 .claim("permissionRole", permissionRole)
@@ -100,7 +101,7 @@ public class JwtUtilImpl implements JwtUtil {
 
     @Override
     public Authentication getAuthentication(String token) {
-        CustomUserDetails userDetails = userDetailService.loadUserByUsername(getClientId(token));
+        CustomUserDetails userDetails = userDetailService.loadUserByUsername(Long.toString(getMemberId(token)));
         return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }
 

--- a/src/main/java/com/otechdong/moyeo/domain/test/controller/TestController.java
+++ b/src/main/java/com/otechdong/moyeo/domain/test/controller/TestController.java
@@ -1,5 +1,7 @@
 package com.otechdong.moyeo.domain.test.controller;
 
+import com.otechdong.moyeo.domain.config.AuthenticationMember;
+import com.otechdong.moyeo.domain.member.entity.Member;
 import com.otechdong.moyeo.global.common.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -49,6 +51,14 @@ public class TestController {
         Map<String, String> responseData = new HashMap<>();
 
         return env;
+    }
+
+    @GetMapping("/test")
+    private String getClientId(
+            @AuthenticationMember Member member
+    ) {
+        System.out.println(member);
+        return "Good";
     }
 
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#23/authenticationMember -> develop

### 변경 사항
- AuthenticationMemeber 커스텀 어노테이션 구현
- 인증된 사용자를 받기 위한 SecurityConfig 설정 변경("/test"에 .authenticated() 설정)
- 필터 통과를 위한 Jwt claim("tokenType", "access") 추가
- 인증 정보 추출 함수(getAuthentication())에서 userDetails를 얻기 위한 파라미터 변경

### 테스트 결과
|성공|실패|
|---|---|
<img width="653" alt="image" src="https://github.com/user-attachments/assets/804bb530-87f6-41f6-a7ae-5b1b8f8e1e27">|<img width="668" alt="image" src="https://github.com/user-attachments/assets/f056095a-7430-489a-921b-404e99688431">|


